### PR TITLE
Default to full backtrace on panic

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -297,7 +297,7 @@ pub fn get_backtrace_style() -> Option<BacktraceStyle> {
 
     // Setting environment variables for Fuchsia components isn't a standard
     // or easily supported workflow. For now, display backtraces by default.
-    let format = if cfg!(target_os = "fuchsia") {
+    let format = if cfg!(any(target_os = "fuchsia", target_os = "switch")) {
         BacktraceStyle::Full
     } else {
         crate::env::var_os("RUST_BACKTRACE")


### PR DESCRIPTION
Shows the full backtrace by default on a panic since it's not possible to set environment variables on the Switch. `set_backtrace_style` can be used as an alternative, but displaying the full backtrace by default is probably still less confusing to new users.