### PR TITLE
Don't call `pthread_condattr_setclock` when initializing condvar

### DIFF
--- a/library/std/src/sys/sync/condvar/pthread_switch.rs
+++ b/library/std/src/sys/sync/condvar/pthread_switch.rs
@@ -32,7 +32,7 @@ impl AllocatedCondvar {
                 target_vendor = "apple",
             ))] {
                 // `pthread_condattr_setclock` is unfortunately not supported on these platforms.
-            } else if #[cfg(any(target_os = "espidf", target_os = "horizon", target_os = "teeos"))] {
+            } else if #[cfg(any(target_os = "espidf", target_os = "horizon", target_os = "teeos", target_os = "switch"))] {
                 // NOTE: ESP-IDF's PTHREAD_COND_INITIALIZER support is not released yet
                 // So on that platform, init() should always be called
                 // Moreover, that platform does not have pthread_condattr_setclock support,


### PR DESCRIPTION
Not all versions of nnsdk support `pthread_condattr_setclock` (according to my research it was only added in version 14), so don't try to call it like other platform not supporting it

See also: [this](https://discord.com/channels/269333940928512010/383368936466546698/1352777861181739081) related conversation on reswitched discord about trying to get tokio working under skyline, and, likely, running into this function being unimplemented.